### PR TITLE
Boyscout: Fix typo

### DIFF
--- a/Kashmir/Shared/URLResponseStatusCode.swift
+++ b/Kashmir/Shared/URLResponseStatusCode.swift
@@ -36,7 +36,7 @@ extension URLResponse {
         /// The request has been fulfilled, resulting in the creation of a new resource.
 		case created = 201
         /// The server successfully processed the request and is not returning any content.
-		case noContest = 204
+		case noContent = 204
 
 		// MARK: 3XX - Redirection
 


### PR DESCRIPTION
Hi there, I like your lib!

It's got lots of useful utilities. On of the particular things I like about it is the use of nested types. Apple seems to be doing this more and more as well.

Anyway, I couldn't help but spot a typo and took the opportunity to fix it. Since this is in an enum case I would consider it a breaking change.

Kind regards,
Menno